### PR TITLE
[FEAT] Add `/service` endpoint

### DIFF
--- a/app/endpoints/service.py
+++ b/app/endpoints/service.py
@@ -1,10 +1,6 @@
 import logging
 from enum import Enum
 
-from fastapi import APIRouter, Depends
-
-from app.utils.auth import is_superuser_required
-from app.utils.schemas import User
 
 router = APIRouter()
 
@@ -20,7 +16,6 @@ class ServiceActions(Enum):
     disable: str = "disable"
 
 @router.post(path="/service",tags=["server"])
-def service_actions(svc:str,action:ServiceActions,current_user: User = Depends(is_superuser_required())):
     """
     Systemctl actions for linux server \n
     **Supports** : *[start, stop, restart, reload, enable, disable]*

--- a/app/endpoints/service.py
+++ b/app/endpoints/service.py
@@ -1,6 +1,7 @@
 import logging
 from enum import Enum
 
+from fastapi import APIRouter
 
 router = APIRouter()
 
@@ -16,6 +17,7 @@ class ServiceActions(Enum):
     disable: str = "disable"
 
 @router.post(path="/service",tags=["server"])
+def service_actions(svc:str,action:ServiceActions):
     """
     Systemctl actions for linux server \n
     **Supports** : *[start, stop, restart, reload, enable, disable]*

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ async def lifespan():
     yield
     logger.critical("Shutting down Application")
     # Close database connection
-    engine.dispose()
+
 
 
 @app.get("/", tags=["default"], name="root", summary="Root endpoint to check if the service is running")
@@ -37,6 +37,9 @@ app.include_router(reload.router)
 
 # #### LOGGER ACTIONS ####
 app.include_router(log.router)
+
+# #### SERVICE ACTIONS ####
+app.include_router(service.router)
 
 # #### SERVICE ACTIONS ####
 app.include_router(service.router)

--- a/helper_scripts/autodoc.py
+++ b/helper_scripts/autodoc.py
@@ -6,6 +6,17 @@ This file will create a readme file with all the endpoints and its usage with ex
 Usage :
 1. Run the project (This will create openapi.json serving in localhost:8000/openapi.json)
 2. Run this script to create the documentation and validate is everything looks good
+
+Sample .env file (To be saved in app root dir)
+
+```
+ad_server=
+ad_username=
+ad_password=
+ad_domain=
+ad_basecn=
+```
+
 """
 
 # URL of the OpenAPI spec


### PR DESCRIPTION
## Summary
Create a single API endpoint to manage systemctl services, including starting, stopping, restarting, reloading, enabling, and disabling services. This will provide a unified interface for controlling services dynamically via API calls.

## Endpoint: /service/status
Method: GET
Query Parameters:
svc (string, required): The name of the service to check.
action (string, optional): The action to perform, one of start, stop, restart, reload, enable, or disable. (Defaults to check status)

## Response:
- Success message indicating the action performed.
- Error message if the action fails.
- JSON object with the status of the service.

## POST /service
Summary: Service Actions
Description: Systemctl actions for linux server
Supports : [start, stop, restart, reload, enable, disable]

## Parameters:

svc (in query)

 -- Required: True

action (in query)

 -- Required: True

## Responses:
Status Code: 200
Description: Successful Response
Status Code: 422
Description: Validation Error
Schema Reference: [HTTPValidationError](http://localhost:63342/markdownPreview/1035700988/markdown-preview-index-2096786478.html?_ijt=4t27v8rj3rm1er7413q679r8mg#httpvalidationerror)
### cURL Command:

```
curl -X POST 'http://127.0.0.1:8000/service'
```

## GET /service
Summary: Service Status
Description: Systemctl status for linux server
Supports : [status]

## Parameters:
svc (in query)

 -- Required: True

## Responses:
- Status Code: 200
 
  - Description: Successful Response
- Status Code: 422
  - Description: Validation Error

### cURL Command:
```
curl -X GET 'http://127.0.0.1:8000/service'
```